### PR TITLE
feat: propose change commitMessage

### DIFF
--- a/src/cli/commit/index.ts
+++ b/src/cli/commit/index.ts
@@ -38,8 +38,7 @@ async function regularCommit(
         : await promptLine("commit message", maxMessageLength, maxMessageLength - 10);
 
     const commitMessage =
-        kind +
-        (scope ? ` ${scope}:` : "") +
+        (scope ? `${scope}(${kind}):` : `${kind}`) +
         (message ? ` ${message}` : " ") +
         (issue ? `\n\n(${issue})` : "");
 


### PR DESCRIPTION
If we want to respect the [convention for commit message](https://github.com/conventional-changelog/conventional-changelog/blob/a5505865ff3dd710cf757f50530e73ef0ca641da/conventions/angular.md), the scope should be on first position when exist, then I propose to add the emoji inside the parentheses. 

So before this PRs:  
`:sparkles: feat: commit message`

After:
`feat(:sparkles:): commit message`
