### PR TITLE
Update supported node version to >=18.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "typescript": "4.8.4"
     },
     "engines": {
-        "node": "18"
+        "node": ">=18.0.0"
     },
     "packageManager": "yarn@3.2.0"
 }


### PR DESCRIPTION
Was there a reason 18 was the only node version supported? 

If not I suggest this change to support newer versions. This will remove the following warning when installing the package.
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'koumu@0.3.3',
npm WARN EBADENGINE   required: { node: '18' },
npm WARN EBADENGINE   current: { node: 'v20.11.1', npm: '10.2.4' }
npm WARN EBADENGINE }
```